### PR TITLE
Update train.py

### DIFF
--- a/PT-BOSS/train.py
+++ b/PT-BOSS/train.py
@@ -104,7 +104,7 @@ def train_one_epoch(
         
         ims_x_strong = ims_x_strong.cuda()
         ims_x_weak = ims_x_weak.cuda()
-        lbs_x = lbs_x.cuda()
+        lbs_x = lbs_x.type(torch.LongTensor).cuda()
         ims_u_weak = ims_u_weak.cuda()
         ims_u_strong = ims_u_strong.cuda()
 
@@ -127,7 +127,7 @@ def train_one_epoch(
             with torch.no_grad():
                 lbs_u_real = lbs_u_real[valid_u].cuda()
                 corr_lb = lbs_u_real == lbs_u
-                loss_u_real = F.cross_entropy(logits_u, lbs_u_real)
+                loss_u_real = F.cross_entropy(logits_u, lbs_u_real.type(torch.LongTensor).cuda())
         else:
             logits_x = model(ims_x_weak)
             loss_x = criteria_x(logits_x, lbs_x)


### PR DESCRIPTION
I'm getting the following error when I run this:

```
Exception has occurred: RuntimeError
Expected object of scalar type Long but got scalar type Int for argument #2 'target' in call to _thnn_nll_loss_forward
  File "C:\Users\Julius\Documents\GitHub\BOSS\PT-BOSS\train.py", line 133, in train_one_epoch
    loss_x = criteria_x(logits_x, lbs_x)
  File "C:\Users\Julius\Documents\GitHub\BOSS\PT-BOSS\train.py", line 302, in train
    train_one_epoch(**train_args)
  File "C:\Users\Julius\Documents\GitHub\BOSS\PT-BOSS\train.py", line 316, in <module>
    train()
```

I think this is because some of the variables are Ints but they need to be Longs, so I've converted them.